### PR TITLE
search param an Sprachwechsler angehängt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -118,6 +118,10 @@ if (rex::isBackend() && rex::getUser()) {
 
             if (Wildcard::isClangSwitchMode()) {
                 $hrefParams = [];
+                $search_term = rex_request('search-term', 'string', '');
+                if ($search_term != '') {
+                    $hrefParams['search-term'] = $search_term;
+                }
                 $pidItems = [];
                 if ('edit' === rex_request('func', 'string') && 0 <= rex_request('pid', 'int', 0)) {
                     $hrefParams['pid'] = rex_request('pid', 'int', 0);


### PR DESCRIPTION
![Zwischenablage-2](https://github.com/user-attachments/assets/b4efc656-f6fb-4c86-aff1-62e462b3a2c8)

Jetzt bleibt der Suchfilter erhalten beim Wechsel der Sprachen.

fixes #82 

